### PR TITLE
fix: exclude demos from package

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,6 +5,7 @@
   "exclude": [
     "src/demo",
     "src/__tests__",
+    "src/**/__demos__/**/*.*",
     "src/**/__tests__/**/*.*",
     "src/**/__bench__/**/*.*",
     "src/**/__mocks__/**/*.*",


### PR DESCRIPTION
Currently these are being included in the published package, when they're not needed